### PR TITLE
FIX: Include the main project, when counting the total number of projects to build.

### DIFF
--- a/src/csnGUIHandler.py
+++ b/src/csnGUIHandler.py
@@ -175,7 +175,7 @@ class Handler:
             # check if CMake is present
             self.CheckCMake()
         
-            nProjects = len(instance.dependenciesManager.GetProjects(_recursive = True))
+            nProjects = len(instance.dependenciesManager.GetProjects(_recursive = True, _includeSelf = True))
             argList = [self.context.GetCmakePath(), "-G", self.context.GetCompiler().GetName(), instance.GetCMakeListsFilename()]
             
             if self.__ConfigureProject(argList, instance.GetBuildFolder(), nProjects):


### PR DESCRIPTION
Otherwise the percentage of the progress bar will be incorrect or CSnake even crashes because of a division by 0.
