### PR TITLE
Fix #67: The function CreateHeader(Do) works with subfolders now.

### DIFF
--- a/src/csnProject.py
+++ b/src/csnProject.py
@@ -370,8 +370,9 @@ class GenericProject(VeryGenericProject):
             filename = "%s.h" % projectNameClean
         path = "%s/%s" % (self.GetBuildFolder(), filename)
         
-        # TODO: Only create the header, if it either doesn't exist or source has changed
-        # TODO: Create directory, if it doesn't exist
+        directory = os.path.dirname(path)
+        if not os.path.exists(directory):
+            os.makedirs(directory)
         headerFile = open(path, 'w')
         
         # header


### PR DESCRIPTION
Fix (#67): The function CreateHeader(Do) (that was moved from csnCilab and Gimias/Toolkit repository to the core of CSnake when creating the API) now also works for filenames containing (not yet existing) subfolders.
