### PR TITLE
Bug in API: api.RewrapProject + custom member functions; fixes #66

### DIFF
--- a/src/csnAPIImplementation.py
+++ b/src/csnAPIImplementation.py
@@ -605,7 +605,7 @@ class _API_Base:
             raise APIError("Unknown project type: %s" % str(type(project)))
         # Add the custom member functions to the new wrapper
         if not (customMemberFunctions is None):
-            for name, function in customMemberFunctions:
+            for name, function in customMemberFunctions.items():
                 # Note: No need to bind the function to the new project wrapper - it's better to pass the object using a
                 #       wrapper of the API version with which the project was created
                 project.__dict__[name] = function


### PR DESCRIPTION
Fixed bug in API (#66): When there were custom member functions and the project had to be rewrapped to another API version, the function RewrapProject threw an exception saying that "there are too many values to unwrap" in the for loop.
