### PR TITLE
ENH: Added CMake project compiler specific settings

### DIFF
--- a/src/csnGUIHandler.py
+++ b/src/csnGUIHandler.py
@@ -188,8 +188,12 @@ class Handler:
             self.CheckCMake()
         
             nProjects = len(instance.dependenciesManager.GetProjects(_recursive = True, _includeSelf = True))
-            argList = [self.context.GetCmakePath(), "-G", self.context.GetCompiler().GetName(), instance.GetCMakeListsFilename()]
-            
+            #argList = [self.context.GetCmakePath(), "-G", self.context.GetCompiler().GetName(), instance.GetCMakeListsFilename()]
+            argList = [self.context.GetCmakePath(), \
+                  "-G", self.context.GetCompiler().GetName()] + \
+                  self.context.GetCompiler().GetProjectCMakeParameters() + \
+                  [instance.GetCMakeListsFilename()]
+
             if self.__ConfigureProject(argList, instance.GetBuildFolder(), nProjects):
                 self.generator.PostProcess(instance)
             else:

--- a/src/csnLinuxCommon.py
+++ b/src/csnLinuxCommon.py
@@ -40,6 +40,9 @@ class LinuxCommon(csnCompiler.Compiler):
             "-D", "CMAKE_CXX_FLAGS=-fPIC"
         ]
     
+    def GetProjectCMakeParameters(self):
+        return []
+    
     def GetAllowedConfigurations(self):
         return ["Debug", "Release"]
     

--- a/src/csnNMake.py
+++ b/src/csnNMake.py
@@ -36,6 +36,9 @@ class Compiler(csnCompiler.Compiler):
     def GetThirdPartyCMakeParameters(self):
         return []
     
+    def GetProjectCMakeParameters(self):
+        return []
+    
     def GetAllowedConfigurations(self):
         return ["DebugAndRelease"]
     

--- a/src/csnVisualStudio2003.py
+++ b/src/csnVisualStudio2003.py
@@ -36,6 +36,9 @@ class Compiler(csnCompiler.Compiler):
     def GetThirdPartyCMakeParameters(self):
         return []
     
+    def GetProjectCMakeParameters(self):
+        return []
+    
     def GetAllowedConfigurations(self):
         return ["DebugAndRelease"]
     

--- a/src/csnVisualStudio2005.py
+++ b/src/csnVisualStudio2005.py
@@ -36,6 +36,9 @@ class Compiler(csnCompiler.Compiler):
     def GetThirdPartyCMakeParameters(self):
         return []
     
+    def GetProjectCMakeParameters(self):
+        return []
+    
     def GetAllowedConfigurations(self):
         return ["DebugAndRelease"]
     

--- a/src/csnVisualStudio2008.py
+++ b/src/csnVisualStudio2008.py
@@ -36,6 +36,9 @@ class Compiler(csnCompiler.Compiler):
     def GetThirdPartyCMakeParameters(self):
         return []
     
+    def GetProjectCMakeParameters(self):
+        return []
+    
     def GetAllowedConfigurations(self):
         return ["DebugAndRelease"]
     

--- a/src/csnVisualStudio2010.py
+++ b/src/csnVisualStudio2010.py
@@ -36,6 +36,9 @@ class Compiler(csnCompiler.Compiler):
     def GetThirdPartyCMakeParameters(self):
         return []
     
+    def GetProjectCMakeParameters(self):
+        return []
+    
     def GetAllowedConfigurations(self):
         return ["DebugAndRelease"]
     

--- a/src/csnVisualStudio2012.py
+++ b/src/csnVisualStudio2012.py
@@ -34,7 +34,10 @@ class Compiler(csnCompiler.Compiler):
         return ""
     
     def GetThirdPartyCMakeParameters(self):
-        return []
+        return ["-T","v110_xp"]
+    
+    def GetProjectCMakeParameters(self):
+        return ["-T","v110_xp"]
     
     def GetAllowedConfigurations(self):
         return ["DebugAndRelease"]


### PR DESCRIPTION
Allow to use v110_xp flag for VS2012 for Windows XP compatibility
