### PR TITLE
Fix CMake warnings "Argument not separated from preceding token by whitespace" (#100) by properly separating the arguments.

### DIFF
--- a/src/csnTests.py
+++ b/src/csnTests.py
@@ -63,9 +63,8 @@ class Manager:
         depends = []
         for source in self.testProject.GetSources():
             if os.path.splitext(source)[1] in (".h", ".hpp"):
-                depend = "\"%s\"" % source
-                depends.append( depend )
-                command += depend
+                depends.append( '"%s"' % source )
+                command += ' "%s"' % source
         self.testProject.AddRule("Create test runner", self.testRunnerSourceFile, command, depends)
         self.testProject.AddCMakeInsertAfterTarget(CustomCMakeLinesTest, self.testProject)
         self.holdingProject.AddCMakeInsertBeginning(CustomCMakeLinesTestHoldingProject, self.holdingProject)


### PR DESCRIPTION
Close #100